### PR TITLE
msm: camera: isp: Use boot clock for recording start time

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp_util.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp_util.c
@@ -198,7 +198,7 @@ void msm_isp_get_timestamp(struct msm_isp_timestamp *time_stamp,
 		time_stamp->buf_time.tv_sec    = time_stamp->vt_time.tv_sec;
 		time_stamp->buf_time.tv_usec   = time_stamp->vt_time.tv_usec;
 	} else	{
-		get_monotonic_boottime(&ts);
+		ktime_get_ts(&ts);
 		time_stamp->buf_time.tv_sec    = ts.tv_sec;
 		time_stamp->buf_time.tv_usec   = ts.tv_nsec/1000;
 	}


### PR DESCRIPTION
 * Our camera HAL uses boot time for buffer timestamp, rather than
   system monotonic time. This leads to issues as framework uses system
   monotonic time as reference start time for timestamp adjustment.
 * This patch is taken from stock kernel source.

Change-Id: Ia4fac1d48e2206a7befd0030585776371dd8c3a9