### PR TITLE
Revert "HACK: arm64: add CNTPCT_EL0 trap handler"

### DIFF
--- a/arch/arm64/kernel/traps.c
+++ b/arch/arm64/kernel/traps.c
@@ -419,19 +419,6 @@ static void cntfrq_read_handler(unsigned int esr, struct pt_regs *regs)
 	regs->pc += 4;
 }
 
-static void cntpct_read_handler(unsigned int esr, struct pt_regs *regs)
-{
-	int rt = (esr & ESR_ELx_SYS64_ISS_RT_MASK) >> ESR_ELx_SYS64_ISS_RT_SHIFT;
-
-	isb();
-	if (rt != 31)
-		regs->regs[rt] = arch_counter_get_cntpct();
-	regs->pc += 4;
-}
-
-#define ESR_ELx_SYS64_ISS_SYS_CNTPCT    (ESR_ELx_SYS64_ISS_SYS_VAL(3, 3, 1, 14, 0) | \
-                                         ESR_ELx_SYS64_ISS_DIR_READ)
-
 asmlinkage void __exception do_sysinstr(unsigned int esr, struct pt_regs *regs)
 {
 	if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTVCT) {
@@ -439,9 +426,6 @@ asmlinkage void __exception do_sysinstr(unsigned int esr, struct pt_regs *regs)
 		return;
 	} else if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTFRQ) {
 		cntfrq_read_handler(esr, regs);
-		return;
-	} else if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTPCT) {
-		cntpct_read_handler(esr, regs);
 		return;
 	}
 


### PR DESCRIPTION
This reverts commit ed94e0bf605251d2c744dfeb7cabcb0fe0288b5e.

Change-Id: Ib58a318c8d19e0c9798ff4311a4133d3ccc0de97